### PR TITLE
Update version of sensio/distribution-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/assetic-bundle": "2.8.1",
         "symfony/swiftmailer-bundle": "2.4.*",
         "symfony/monolog-bundle": "3.0.*",
-        "sensio/distribution-bundle": "5.0.*",
+        "sensio/distribution-bundle": "5.0.24",
         "sensio/framework-extra-bundle": "3.0.*",
         "incenteev/composer-parameter-handler": "2.1.2",
         "jms/serializer": "1.5.0",


### PR DESCRIPTION
security:check is failed in version 5.0.22 and below